### PR TITLE
feat(deploy): added kubernetes deploy

### DIFF
--- a/kubernetes/api-gateway-data-persistentvolumeclaim.yaml
+++ b/kubernetes/api-gateway-data-persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: api-gateway-data
+  name: api-gateway-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/kubernetes/api-gateway-deployment.yaml
+++ b/kubernetes/api-gateway-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o kubernetes/
+    kompose.version: 1.34.0 (HEAD)
+  labels:
+    io.kompose.service: api-gateway
+  name: api-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: api-gateway
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -o kubernetes/
+        kompose.version: 1.34.0 (HEAD)
+      labels:
+        io.kompose.service: api-gateway
+    spec:
+      containers:
+        - image: ghcr.io/fis2425/api-gateway:latest
+          name: api-gateway
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+      restartPolicy: Always

--- a/kubernetes/api-gateway-service.yaml
+++ b/kubernetes/api-gateway-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o kubernetes/
+    kompose.version: 1.34.0 (HEAD)
+  labels:
+    io.kompose.service: api-gateway
+  name: api-gateway
+spec:
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    io.kompose.service: api-gateway


### PR DESCRIPTION
This pull request introduces new Kubernetes configurations for the `api-gateway` service, including a PersistentVolumeClaim, Deployment, and Service. These changes are essential for setting up the `api-gateway` service within a Kubernetes cluster.

Kubernetes configurations:

* Added a PersistentVolumeClaim to request 100Mi of storage for the `api-gateway-data` service in `kubernetes/api-gateway-data-persistentvolumeclaim.yaml`.
* Created a Deployment for the `api-gateway` service with one replica, using the `ghcr.io/fis2425/api-gateway:latest` image in `kubernetes/api-gateway-deployment.yaml`.
* Defined a LoadBalancer Service for the `api-gateway` to expose port 8080 in `kubernetes/api-gateway-service.yaml`.