### PR TITLE
fix: output path on merger

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Checkout ⬇️
         uses: actions/checkout@v4.2.2
         with:
+          ref: main
           show-progress: false
 
       - name: Cache Dependencies 📦
@@ -37,16 +38,9 @@ jobs:
         run: cargo build --verbose
 
       - name: Generate OpenAPI Spec 📜
-        run: cargo run -- merge --url 'http://0.0.0.0:8080' --specs './docs/' --output './static/openapi.html'
-
-      - name: Check if the schema was modified 🧐
-        id: diff
-        run: |
-          diff=$(git status -su | grep static/openapi.yaml | wc -l)
-          echo "diff=$diff" >> $GITHUB_ENV
+        run: cargo run -- merge --url 'http://0.0.0.0:8080' --specs './docs/' --output './static/openapi.yaml'
 
       - name: Commit changes 📤
-        if: ${{ env.diff != '0' && github.event_name == 'push' }}
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ cargo run -- merge --url <URL> --specs <SPEC_DIR> --output <OUTPUT_PATH>
 #### Example:
 
 ```bash
-cargo run -- merge --url "http://0.0.0.0:8080" --specs "./docs/" --output "./static/openapi.html"
+cargo run -- merge --url "http://0.0.0.0:8080" --specs "./docs/" --output "./static/openapi.yaml"
 ```
 
 In this example, the command merges the OpenAPI specs located in the `docs/` directory and generates a merged HTML spec at `static/openapi.html`. The `--url` argument specifies the API Gateway URL.


### PR DESCRIPTION
This pull request includes a change to massive skill issue that i had with the OpenAPI specification generation process in the GitHub Actions workflow file. The most important change is the modification of the output format for the generated OpenAPI specification.

Changes to OpenAPI specification generation:

* [`.github/workflows/openapi.yml`](diffhunk://#diff-3037eb4d8d7d81bdfc122e300300d61f27902de7f07a0177176690cf5aebcc68L40-R40): Changed the output format of the generated OpenAPI specification from HTML to YAML.