### PR TITLE
config: add workflow to deploy to AKS

### DIFF
--- a/.github/workflows/deploy-aks.yaml
+++ b/.github/workflows/deploy-aks.yaml
@@ -1,0 +1,35 @@
+name: Deploy to AKS
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Build and Push Docker Image
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up KUBECONFIG
+      uses: azure/k8s-set-context@v4
+      with:
+        kubeconfig: ${{ secrets.KUBECONFIG }}
+    
+    - name: Apply manifests
+      run: |
+        echo "Apply manifests..."
+        kubectl apply -f kubernetes/
+    
+    - name: Restart specified deployments
+      run: |
+        echo "Restarting api-gateway ..."
+        kubectl rollout restart deployment api-gateway


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment process to Azure Kubernetes Service (AKS). The workflow is designed to trigger upon the successful completion of the "Build and Push Docker Image" workflow and includes several key steps to ensure the deployment is carried out smoothly.

Key changes include:

* **New Workflow Addition**:
  * [`.github/workflows/deploy-aks.yaml`](diffhunk://#diff-a66c1dacd10d71e632b714c354bb07e61702e1d6ce64c8856eabbb1feda30c2dR1-R35): Added a new workflow named "Deploy to AKS" that triggers on the completion of the "Build and Push Docker Image" workflow and runs on the `main` branch.

* **Deployment Steps**:
  * **Checkout Code**: Uses the `actions/checkout@v3` action to check out the code from the repository.
  * **Set Up KUBECONFIG**: Uses the `azure/k8s-set-context@v4` action to set up the Kubernetes configuration using a secret.
  * **Apply Manifests**: Runs a shell command to apply the Kubernetes manifests located in the `kubernetes/` directory.
  * **Restart Deployments**: Runs a shell command to restart the `api-gateway` deployment using `kubectl rollout restart`.